### PR TITLE
Fix HTTP client connection management

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,10 +27,12 @@ func newClient(
 	compress bool,
 	https bool,
 	reuse bool,
+	maxConn uint,
 ) *http.Client {
 	tr := http.Transport{
-		DisableCompression: !compress,
-		DisableKeepAlives:  !reuse,
+		DisableCompression:  !compress,
+		DisableKeepAlives:   !reuse,
+		MaxIdleConnsPerHost: int(maxConn),
 	}
 	if https {
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -116,7 +118,7 @@ func main() {
 	timeToWait := time.Millisecond * time.Duration(1000 / *qps)
 
 	doTLS := dstURL.Scheme == "https"
-	client := newClient(*compress, doTLS, *reuse)
+	client := newClient(*compress, doTLS, *reuse, *concurrency)
 
 	for i := uint(0); i < *concurrency; i++ {
 		ticker := time.NewTicker(timeToWait)


### PR DESCRIPTION
There were two problems with the existing code:
- compression, etc settings were not set when client reuse was disabled
- there was no mechanism to release unused client connections, causing FD exhaustion

In order to fix this, we can simply use one HTTP client with DisableKeepAlives
set when reuse is not enabled.
