### PR TITLE
Fixes bug when qps calculation results in fractional milliseconds getting rounded off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Improved qps calculation when fractional milliseconds are involved. (Fixed #5)
 ### Added
 - You can now pass a CSV of Host headers and it will fairly split traffic with each Host header.
 

--- a/qps_test.go
+++ b/qps_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQpsCalc(t *testing.T) {
+	// At 100 qps, we expect to wait 10 milliseconds
+	checkDuration(100, 10, t)
+	// At 1000 qps, we expect to wait 1 milliseconds
+	checkDuration(1000, 1, t)
+	// At 150 qps, we expect to wait 6.666 milliseconds
+	checkDuration(150, 6.666666, t)
+	// At 134 qps, we expect to wait 7.462 milliseconds
+	checkDuration(134, 7.462686, t)
+}
+
+func checkDuration(targetQps int, expectedWaitTimeMs float64, t *testing.T) {
+	expected := time.Duration(expectedWaitTimeMs * float64(time.Millisecond))
+	got := CalcTimeToWait(&targetQps)
+	if expected != got {
+		t.Errorf("For %d qps, expected to wait %s, instead we wait %s",
+			targetQps, expected, got)
+	}
+}


### PR DESCRIPTION
When qps calculations result in fractional milliseconds, the target qps is off due to rounding. Converting to nanoseconds fixes that.

Fixes #5
