### PR TITLE
adds a summary latency report and a latency CSV file output option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added percent success to the output.
 - Added target traffic per interval to the output.
+- Optional latency histogram report to stdout.
+- Optional full latency CSV report to a given filename.
 ### Changed
 - Removed `-reuse` deprecation warning.
 - Removed bytes received from the output.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Do not reuse connections. (Connection reuse is the default.)
 
 Ask for compressed responses.
 
+`-noLatencySummary`
+
+Don't print the latency histogram report at the end.
+
+`-reportLatenciesCSV <filename>`
+
+Writes a CSV file of latencies. Format is: milliseconds to number of
+requests that fall into that bucket.
 
 # Using multiple Host headers
 

--- a/hdrreport/hdrreport.go
+++ b/hdrreport/hdrreport.go
@@ -1,0 +1,68 @@
+package hdrreport
+
+import (
+	"fmt"
+	"github.com/codahale/hdrhistogram"
+	"os"
+)
+
+func WriteReportCSV(filename *string, hist *hdrhistogram.Histogram) error {
+	f, err := os.Create(*filename)
+
+	if err != nil {
+		return err
+	}
+
+	for _, bar := range hist.Distribution() {
+		_, err := f.Write([]byte(bar.String()))
+
+		if err != nil {
+			return err
+		}
+	}
+
+	err = f.Sync()
+
+	if err != nil {
+		return err
+	}
+
+	err = f.Close()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func PrintLatencySummary(hist *hdrhistogram.Histogram) {
+	fmt.Printf("FROM    TO #REQUESTS\n")
+	fmt.Printf("   0     2 %d\n", SumBars(0, 2, hist.Distribution()))
+	fmt.Printf("   2     8 %d\n", SumBars(2, 8, hist.Distribution()))
+	fmt.Printf("   8    32 %d\n", SumBars(8, 32, hist.Distribution()))
+	fmt.Printf("  32    64 %d\n", SumBars(32, 64, hist.Distribution()))
+	fmt.Printf("  64   128 %d\n", SumBars(64, 128, hist.Distribution()))
+	fmt.Printf(" 128   256 %d\n", SumBars(128, 256, hist.Distribution()))
+	fmt.Printf(" 256   512 %d\n", SumBars(256, 512, hist.Distribution()))
+	fmt.Printf(" 512  1024 %d\n", SumBars(512, 1024, hist.Distribution()))
+	fmt.Printf("1024  4096 %d\n", SumBars(1024, 4096, hist.Distribution()))
+	fmt.Printf("4096 16384 %d\n", SumBars(4096, 16384, hist.Distribution()))
+}
+
+// Given a sorted `[]hdrhistogram.Bar`, return the sum of every `Bar` in the
+// Range of (from, to]. Inclusive of from, exclusive of to.
+func SumBars(from int64, to int64, bars []hdrhistogram.Bar) int64 {
+	count := int64(0)
+	for _, bar := range bars {
+		if bar.To >= to {
+			// short circuit if we've passed the item
+			// we're interested in.
+			break
+		}
+		if bar.From >= from && bar.To < to {
+			count = count + bar.Count
+		}
+	}
+	return count
+}


### PR DESCRIPTION
We also change the hdrhistogram size to fit a day's worth of latency in milliseconds. This naturally gives us a nice report of latency by millisecond and also removes the need to covert from nanoseconds to milliseconds on output.
