### PR TITLE
Adds a change indicator denotating latency changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added percent success to the output.
 - Added target traffic per interval to the output.
 - Optional latency histogram report to stdout.
+- Adds a change indicator to the end of the line showing how many
+  orders of magnitude this line's p99 is over the previous 5.
 - Optional full latency CSV report to a given filename.
 - Respect `http_proxy` environment variable.
 ### Changed
+- We no longer generate the i386 linux binaries for release.
 - Removed `-reuse` deprecation warning.
 - Removed bytes received from the output.
 - Removed `-url`, instead use the first argument from ARGV.

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,9 @@
+#!/bin/bash
+
+set -ex
+
 GOOS=linux GOARCH=amd64  go build -o slow_cooker_linux_amd64 github.com/buoyantio/slow_cooker
 GOOS=linux GOARCH=arm    go build -o slow_cooker_linux_arm   github.com/buoyantio/slow_cooker
-GOOS=linux GOARCH=386    go build -o slow_cooker_linux_i386  github.com/buoyantio/slow_cooker
 GOOS=darwin GOARCH=amd64 go build -o slow_cooker_darwin      github.com/buoyantio/slow_cooker
 echo "releases built:"
-ls slow_cooker*
+ls slow_cooker_*

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -1,0 +1,22 @@
+package ring
+
+// Provides a ring buffer of integers with a lightweight interface.
+type IntRing struct {
+	Items      []int
+	CurrentIdx int
+}
+
+// Returns an IntRing with a given size.
+func New(size int) IntRing {
+	return IntRing{
+		Items:      make([]int, size),
+		CurrentIdx: 0,
+	}
+}
+
+// Push(item) adds the given item as the most recent item
+// overwriting the oldest item.
+func (r *IntRing) Push(item int) {
+	r.Items[r.CurrentIdx] = item
+	r.CurrentIdx = (r.CurrentIdx + 1) % len(r.Items)
+}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1,0 +1,38 @@
+package ring_test
+
+import (
+	"github.com/buoyantio/slow_cooker/ring"
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type RingTestSuite struct{}
+
+var _ = Suite(&RingTestSuite{})
+
+func (*RingTestSuite) TestRing(c *C) {
+	r := ring.New(5)
+	c.Assert(len(r.Items), Equals, 5)
+
+	for i := 1; i <= 10; i++ {
+		r.Push(i)
+	}
+
+	c.Assert(r.Items, DeepEquals, []int{6, 7, 8, 9, 10})
+
+	// Make a ring of 6 items
+	r = ring.New(6)
+	// Push 7 items
+	r.Push(1)
+	r.Push(10)
+	r.Push(99)
+	r.Push(50)
+	r.Push(77)
+	r.Push(83)
+	r.Push(2)
+	// The oldest item should be gone
+	c.Assert(r.Items, DeepEquals, []int{2, 10, 99, 50, 77, 83})
+}

--- a/window/window.go
+++ b/window/window.go
@@ -1,0 +1,59 @@
+package window
+
+// Returns the mean of a slice of int64.
+func Mean(data []int) int {
+	sum := 0
+
+	for _, n := range data {
+		sum += n
+	}
+
+	count := len(data)
+	if count > 0 {
+		return sum / count
+	} else {
+		return 0
+	}
+}
+
+// Given a window of recent latencies, determine if a Change
+// Indicator should be generated.
+//
+// For each 10x over the mean the latest item is, we add a single plus
+// sign up to 3.
+//
+// For each 10x under the mean the latest item is, we add a single
+// minus sign up to 3.
+//
+// Otherwise we return no change indicator.
+func CalculateChangeIndicator(data []int, latest int) string {
+	mad := Mean(data)
+
+	if len(data) > 0 {
+		if latest >= (mad * 1000) {
+			return "+++"
+		}
+
+		if latest >= (mad * 100) {
+			return "++"
+		}
+
+		if latest >= (mad * 10) {
+			return "+"
+		}
+
+		if latest <= (mad / 1000) {
+			return "---"
+		}
+
+		if latest <= (mad / 100) {
+			return "--"
+		}
+
+		if latest <= (mad / 10) {
+			return "-"
+		}
+	}
+
+	return ""
+}

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -1,0 +1,42 @@
+package window_test
+
+import (
+	"github.com/buoyantio/slow_cooker/window"
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type WindowTestSuite struct{}
+
+var _ = Suite(&WindowTestSuite{})
+
+func (*WindowTestSuite) TestMean(c *C) {
+	data := []int{}
+	c.Assert(window.Mean(data), Equals, 0)
+
+	data = []int{10, 20, 30, 40}
+	c.Assert(window.Mean(data), Equals, 25)
+
+	data = []int{8, 6, 5, 1000}
+	c.Assert(window.Mean(data), Equals, 254)
+
+	data = []int{0, 7, 10, 9, 1000000}
+	c.Assert(window.Mean(data), Equals, 200005)
+}
+
+func (*WindowTestSuite) TestCalculateChangeIndicator(c *C) {
+	data := []int{0, 7, 10, 9}
+	c.Assert(window.CalculateChangeIndicator(data, 1000000), Equals, "+++")
+	c.Assert(window.CalculateChangeIndicator(data, 1000), Equals, "++")
+	c.Assert(window.CalculateChangeIndicator(data, 100), Equals, "+")
+	c.Assert(window.CalculateChangeIndicator(data, 10), Equals, "")
+
+	data = []int{1000000, 1000000, 1000000, 1000000}
+	c.Assert(window.CalculateChangeIndicator(data, 1000000), Equals, "")
+	c.Assert(window.CalculateChangeIndicator(data, 100000), Equals, "-")
+	c.Assert(window.CalculateChangeIndicator(data, 10000), Equals, "--")
+	c.Assert(window.CalculateChangeIndicator(data, 1000), Equals, "---")
+}


### PR DESCRIPTION
Adds a change indicator to the end of the log line detonating if we've
seen a large jump in latency. For each order of magnitude increase, we
add a + sign, up to 3. For order of magnitude decreases, we add a -
sign, up to 3.

To support this, we add a basic ring buffer of integers and a simple Mean
calculation.

We no longer generate i386 linux binaries for release. We got a little
ahead of ourselves with that one.
