### PR TITLE
Minor fixes to appease formatting and linting tools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Optional full latency CSV report to a given filename.
 - Respect `http_proxy` environment variable.
 - Added `-totalRequests` flag for exiting after the given number of requests are issued.
+
 ### Changed
 - We no longer generate the i386 linux binaries for release.
 - Removed `-reuse` deprecation warning.
@@ -26,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - We now output min and max latency numbers bracketing the latency percentiles. (Fixes #13)
 - You can now pass a CSV of Host headers and it will fairly split traffic with each Host header.
 - Each request has a header called Sc-Req-Id with a unique numeric value to help debug proxy interactions.
+
 ### Changed
 - Output now shows good/bad/failed requests
 - Improved qps calculation when fractional milliseconds are involved. (Fixed #5)

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 	"github.com/codahale/hdrhistogram"
 )
 
-// 1 day in milliseconds
-const DAY_IN_MS int64 = 24 * 60 * 60 * 1000000
+// DayInMs 1 day in milliseconds
+const DayInMs int64 = 24 * 60 * 60 * 1000000
 
 // MeasuredResponse holds metadata about the response
 // we receive from the server under test.
@@ -122,7 +122,7 @@ var reqID = uint64(0)
 var shouldFinish = false
 var shouldFinishLock sync.RWMutex
 
-// Signals the system to stop sending traffic and clean up after itself.
+// finishSendingTraffic signals the system to stop sending traffic and clean up after itself.
 func finishSendingTraffic() {
 	shouldFinishLock.Lock()
 	shouldFinish = true
@@ -183,8 +183,8 @@ func main() {
 	min := int64(math.MaxInt64)
 	max := int64(0)
 
-	hist := hdrhistogram.New(0, DAY_IN_MS, 3)
-	globalHist := hdrhistogram.New(0, DAY_IN_MS, 3)
+	hist := hdrhistogram.New(0, DayInMs, 3)
+	globalHist := hdrhistogram.New(0, DayInMs, 3)
 	latencyHistory := ring.New(5)
 	received := make(chan *MeasuredResponse)
 	timeout := time.After(*interval)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1,4 +1,4 @@
-package ring_test
+package ring
 
 import (
 	"github.com/buoyantio/slow_cooker/ring"

--- a/window/window.go
+++ b/window/window.go
@@ -4,7 +4,7 @@ import (
 	"math"
 )
 
-// Returns the mean of a slice of int64.
+// Mean returns the mean of a slice of int64.
 func Mean(data []int) int {
 	sum := 0
 
@@ -15,13 +15,13 @@ func Mean(data []int) int {
 	count := len(data)
 	if count > 0 {
 		return sum / count
-	} else {
-		return 0
 	}
+	return 0
+
 }
 
-// Given a window of recent latencies, determine if a Change
-// Indicator should be generated.
+// CalculateChangeIndicator determines if a Change
+// Indicator should be generated from a window of recent latencies.
 //
 // For each 10x over the mean the latest item is, we add a single plus
 // sign up to 3.

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -1,4 +1,4 @@
-package window_test
+package window
 
 import (
 	"github.com/buoyantio/slow_cooker/window"


### PR DESCRIPTION
CHANGELOG.md needs some newlines to render properly. Fixes #30.
The other changes are based on go lint and go vet complaints.