### PR TITLE
[WIP] Embedded lua to generate dynamic request data

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,12 +24,10 @@ import (
 	"time"
 
 	"github.com/codahale/hdrhistogram"
-	gopherJson "github.com/layeh/gopher-json"
-	"github.com/samdfonseca/slow_cooker/hdrreport"
-	"github.com/samdfonseca/slow_cooker/ring"
-	"github.com/samdfonseca/slow_cooker/scripting"
-	"github.com/samdfonseca/slow_cooker/window"
-	"github.com/yuin/gopher-lua"
+	"github.com/buoyantio/slow_cooker/hdrreport"
+	"github.com/buoyantio/slow_cooker/ring"
+	"github.com/buoyantio/slow_cooker/scripting"
+	"github.com/buoyantio/slow_cooker/window"
 )
 
 // DayInMs 1 day in milliseconds
@@ -210,10 +208,7 @@ func main() {
 		dataGenerator = scripting.NewDataGenerator(
 			scripting.NewLStatePool(*dataGeneratorScript,
 				*concurrency,
-				map[string]func(*lua.LState) int{
-					"slow_cooker": scripting.NewModuleLoader(map[string]lua.LGFunction{}),
-					"gopherJson":  gopherJson.Loader,
-				}),
+				scripting.DefaultModuleLoaders),
 		)
 	}
 
@@ -260,8 +255,8 @@ func main() {
 					reqID = atomic.AddUint64(&reqID, 1)
 					reqData := &scripting.LReqData{
 						Method: *method,
-						Url: dstURL.String(),
-						Host: hosts[rand.Intn(len(hosts))],
+						Url:    dstURL.String(),
+						Host:   hosts[rand.Intn(len(hosts))],
 					}
 					if err := dataGenerator(reqData, reqID); err != nil {
 						panic(err)

--- a/randomstring.lua
+++ b/randomstring.lua
@@ -1,5 +1,5 @@
 slow_cooker = require('slow_cooker')
-json = require('json')
+json = require('gopherJson')
 
 local Built = {}
 
@@ -40,6 +40,11 @@ function string.random(len, charset)
 end
 
 function slow_cooker.generate_data(method, url, host, reqID)
-  local body = {method=method, url=url, host=host, request_id=reqID, random_string=string.random(50)}
-  return json.encode(body)
+  local body = {random_string=string.random(50)}
+  return {
+    method=method,
+    url=string.format('%s/%i', string.gsub(url, '/$', '', 1), reqID),
+    host=host,
+    body=json.encode(body)
+  }
 end

--- a/randomstring.lua
+++ b/randomstring.lua
@@ -1,4 +1,5 @@
 slow_cooker = require('slow_cooker')
+json = require('json')
 
 local Built = {}
 
@@ -39,5 +40,6 @@ function string.random(len, charset)
 end
 
 function slow_cooker.generate_data(method, url, host, reqID)
-  return string.random(50)
+  local body = {method=method, url=url, host=host, request_id=reqID, random_string=string.random(50)}
+  return json.encode(body)
 end

--- a/randomstring.lua
+++ b/randomstring.lua
@@ -1,0 +1,43 @@
+slow_cooker = require('slow_cooker')
+
+local Built = {}
+
+local AddLookup = function(charset)
+  local chars = {}
+  for i = 0, 255 do
+    chars[i + 1] = string.char(i)
+  end
+  local sub = string.gsub(table.concat(chars), '[^' .. charset .. ']', '')
+  local lookup = {}
+  for i = 1, string.len(sub) do
+    lookup[i] = string.sub(sub, i, i)
+  end
+  Built[charset] = lookup
+
+  return lookup
+end
+
+function string.random(len, charset)
+  -- len (number)
+  -- charset (string, optional); e.g. %l%d for lower case letters and digits
+
+  local charset = charset or '%w'
+
+  if charset == '' then
+    return ''
+  else
+    local res = {}
+    local lookup = Built[charset] or AddLookup(charset)
+    local range = #lookup
+
+    for i = 1, len do
+      res[i] = lookup[math.random(1, range)]
+    end
+
+    return table.concat(res)
+  end
+end
+
+function slow_cooker.generate_data(method, url, host, reqID)
+  return string.random(50)
+end

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"github.com/buoyantio/slow_cooker/ring"
 	. "gopkg.in/check.v1"
 	"testing"
 )
@@ -14,7 +13,7 @@ type RingTestSuite struct{}
 var _ = Suite(&RingTestSuite{})
 
 func (*RingTestSuite) TestRing(c *C) {
-	r := ring.New(5)
+	r := New(5)
 	c.Assert(len(r.Items), Equals, 5)
 
 	for i := 1; i <= 10; i++ {
@@ -24,7 +23,7 @@ func (*RingTestSuite) TestRing(c *C) {
 	c.Assert(r.Items, DeepEquals, []int{6, 7, 8, 9, 10})
 
 	// Make a ring of 6 items
-	r = ring.New(6)
+	r = New(6)
 	// Push 7 items
 	r.Push(1)
 	r.Push(10)

--- a/scripting/lua_datagenerator.go
+++ b/scripting/lua_datagenerator.go
@@ -1,0 +1,28 @@
+package scripting
+
+import (
+	"fmt"
+	"github.com/yuin/gopher-lua"
+	"net/url"
+)
+
+func NewDataGenerator(luaPool *lStatePool) func(string, *url.URL, string, uint64) []byte {
+	return func(method string, url *url.URL, host string, reqID uint64) []byte {
+		l := luaPool.Get()
+		defer luaPool.Put(l)
+		if err := l.CallByParam(lua.P{
+			Fn:      l.GetField(l.GetGlobal("slow_cooker"), "generate_data"),
+			NRet:    1,
+			Protect: true,
+		}, lua.LString(method), lua.LString(url.String()), lua.LString(host), lua.LNumber(float64(reqID))); err != nil {
+			panic(err)
+		}
+		defer l.Pop(1)
+		if ret, ok := l.Get(-1).(lua.LString); ok {
+			s := fmt.Sprint(ret)
+			return []byte(s)
+		}
+		panic("Unable to get return value from lua stack")
+	}
+
+}

--- a/scripting/lua_datagenerator.go
+++ b/scripting/lua_datagenerator.go
@@ -1,28 +1,56 @@
 package scripting
 
 import (
-	"fmt"
-	"github.com/yuin/gopher-lua"
+	"errors"
 	"net/url"
+
+	"github.com/yuin/gluamapper"
+	"github.com/yuin/gopher-lua"
 )
 
-func NewDataGenerator(luaPool *lStatePool) func(string, *url.URL, string, uint64) []byte {
-	return func(method string, url *url.URL, host string, reqID uint64) []byte {
+type LReqData struct {
+	Method string
+	Url    string
+	Host   string
+	Body   string
+}
+
+func (reqData *LReqData) GetUrl() (*url.URL, error) {
+	return url.Parse(reqData.Url)
+}
+
+func (reqData *LReqData) MustGetUrl() *url.URL {
+	u, err := reqData.GetUrl()
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func (reqData *LReqData) GetBody() []byte {
+	return []byte(reqData.Body)
+}
+
+// NewDataGenerator returns a function that calls the slow_cooker.generate_data function
+// and retrieves its value from the stack.
+func NewDataGenerator(luaPool *lStatePool) func(*LReqData, uint64) error {
+	return func(reqData *LReqData, reqID uint64) error {
 		l := luaPool.Get()
 		defer luaPool.Put(l)
 		if err := l.CallByParam(lua.P{
 			Fn:      l.GetField(l.GetGlobal("slow_cooker"), "generate_data"),
 			NRet:    1,
 			Protect: true,
-		}, lua.LString(method), lua.LString(url.String()), lua.LString(host), lua.LNumber(float64(reqID))); err != nil {
-			panic(err)
+		}, lua.LString(reqData.Method), lua.LString(reqData.Url), lua.LString(reqData.Host), lua.LNumber(float64(reqID))); err != nil {
+			return err
 		}
 		defer l.Pop(1)
-		if ret, ok := l.Get(-1).(lua.LString); ok {
-			s := fmt.Sprint(ret)
-			return []byte(s)
+		if ret, ok := l.Get(-1).(*lua.LTable); ok {
+			if err := gluamapper.Map(ret, reqData); err != nil {
+				return err
+			}
+			return nil
 		}
-		panic("Unable to get return value from lua stack")
+		return errors.New("Unable to get return value from lua stack")
 	}
-
 }

--- a/scripting/lua_datagenerator_test.go
+++ b/scripting/lua_datagenerator_test.go
@@ -1,0 +1,35 @@
+package scripting
+
+import (
+	"flag"
+	"log"
+	"testing"
+)
+
+var (
+	testScript  = flag.String("script", "", "lua script to benchmark")
+	testMethod  = flag.String("method", "GET", "value of method arg passed to slow_cooker.generate_data")
+	testUrl     = flag.String("url", "localhost", "value of url arg passed to slow_cooker.generate_data")
+	testHost    = flag.String("host", "", "value of host arg passed to slow_cooker.generate_data")
+	concurrency = flag.Int("concurrency", 10, "number of concurrent lua VMs")
+)
+
+func init() {
+	flag.Parse()
+}
+
+func BenchmarkDataGeneratorScript(b *testing.B) {
+	if *testScript == "" {
+		log.Fatal("Missing required -dataGeneratorScript flag")
+	}
+	lPool := NewLStatePool(*testScript, *concurrency, DefaultModuleLoaders)
+	dataGenerator := NewDataGenerator(lPool)
+	for i := 0; i < b.N; i++ {
+		lReqData := &LReqData{
+			Method: *testMethod,
+			Url:    *testUrl,
+			Host:   *testHost,
+		}
+		dataGenerator(lReqData, uint64(i))
+	}
+}

--- a/scripting/lua_slow_cooker.go
+++ b/scripting/lua_slow_cooker.go
@@ -1,0 +1,17 @@
+package scripting
+
+import (
+	"github.com/yuin/gopher-lua"
+)
+
+func NewModuleLoader(exports map[string]lua.LGFunction) func(*lua.LState) int {
+	return func(l *lua.LState) int {
+		// register functions to the module's exported lua table
+		// local slow_cooker = require("slow_cooker")
+		mod := l.SetFuncs(l.NewTable(), exports)
+		l.Push(mod)
+		return 1
+	}
+}
+
+

--- a/scripting/lua_slow_cooker.go
+++ b/scripting/lua_slow_cooker.go
@@ -4,6 +4,9 @@ import (
 	"github.com/yuin/gopher-lua"
 )
 
+// NewModuleLoader creates a new module loader that registers the given functions
+// to the lua module's exported lua table. This can be used to expose Go functions
+// to lua. See https://github.com/yuin/gopher-lua#calling-go-from-lua
 func NewModuleLoader(exports map[string]lua.LGFunction) func(*lua.LState) int {
 	return func(l *lua.LState) int {
 		// register functions to the module's exported lua table
@@ -13,5 +16,3 @@ func NewModuleLoader(exports map[string]lua.LGFunction) func(*lua.LState) int {
 		return 1
 	}
 }
-
-

--- a/scripting/lua_statepool.go
+++ b/scripting/lua_statepool.go
@@ -1,0 +1,57 @@
+package scripting
+
+import (
+	"sync"
+
+	"github.com/yuin/gopher-lua"
+)
+
+type lStatePool struct {
+	m             sync.Mutex
+	saved         []*lua.LState
+	script        string
+	moduleLoaders map[string]func(*lua.LState) int
+}
+
+func NewLStatePool(script string, capacity int, moduleLoaders map[string]func(*lua.LState) int) *lStatePool {
+	return &lStatePool{
+		saved:         make([]*lua.LState, 0, capacity),
+		script:        script,
+		moduleLoaders: moduleLoaders,
+	}
+}
+
+func (pl *lStatePool) Get() *lua.LState {
+	pl.m.Lock()
+	defer pl.m.Unlock()
+	n := len(pl.saved)
+	if n == 0 {
+		return pl.New()
+	}
+	x := pl.saved[n-1]
+	pl.saved = pl.saved[0 : n-1]
+	return x
+}
+
+func (pl *lStatePool) New() *lua.LState {
+	l := lua.NewState()
+	for modName, loader := range pl.moduleLoaders {
+		l.PreloadModule(modName, loader)
+	}
+	if err := l.DoFile(pl.script); err != nil {
+		panic(err)
+	}
+	return l
+}
+
+func (pl *lStatePool) Put(l *lua.LState) {
+	pl.m.Lock()
+	defer pl.m.Unlock()
+	pl.saved = append(pl.saved, l)
+}
+
+func (pl *lStatePool) Shutdown() {
+	for _, l := range pl.saved {
+		l.Close()
+	}
+}

--- a/scripting/lua_statepool.go
+++ b/scripting/lua_statepool.go
@@ -3,8 +3,14 @@ package scripting
 import (
 	"sync"
 
+	gopherJson "github.com/layeh/gopher-json"
 	"github.com/yuin/gopher-lua"
 )
+
+var DefaultModuleLoaders = map[string]func(*lua.LState) int{
+	"slow_cooker": NewModuleLoader(map[string]lua.LGFunction{}),
+	"gopherJson":  gopherJson.Loader,
+}
 
 // A very slightly modified version of the lStatePool from the gopher-lua readme
 // https://github.com/yuin/gopher-lua#the-lstate-pool-pattern

--- a/scripting/lua_statepool.go
+++ b/scripting/lua_statepool.go
@@ -6,6 +6,8 @@ import (
 	"github.com/yuin/gopher-lua"
 )
 
+// A very slightly modified version of the lStatePool from the gopher-lua readme
+// https://github.com/yuin/gopher-lua#the-lstate-pool-pattern
 type lStatePool struct {
 	m             sync.Mutex
 	saved         []*lua.LState


### PR DESCRIPTION
Hi @stevej, sorry for dropping this on you without a heads up, but I'm really just interested in getting some feedback from you regarding the potential for merging this in at some point. 

This PR gives the user the ability to specify a lua script that defines the function `slow_cooker.generate_data`, which is provided the method, url, host, and request id of each request and called to generate the request's body. I've used the awesome [gopher-lua](https://github.com/yuin/gopher-lua) project to handle the communication between the go-side and lua-side.

I was interested in using slow_cooker as a replacement for jMeter since, like jMeter, it gives results as a time-series. However, the endpoint I needed to test validates a certain element on the request body for uniqueness. The changes I made allow me to have a single `slow_cooker` binary, and a series of lua scripts to generate the request body according to different scenarios. My previous approach was to modify the go source for each scenario and compile separate binaries. The overhead of the lua VM, while I'm sure it is non-zero, seems to be negligible, although I haven't tested this too extensively. Whatever overhead does exist will only be incurred when using the `-dataGeneratorScript` flag.

The changes I've made are far from final yet, and I haven't settled on certain decisions, such as if the lua-side should be able to modify any part of the request or just generate the body. My interest is mainly just to see if you could envision a version of this being merged in, since that will dictate how diverging some of the changes I make should be. Thanks!

```
→ time ./slow_cooker_without_lua -qps 100 -concurrency 10 -method POST -totalRequests 10000 http://httpbin.org/post
# sending 1000 POST req/s with concurrency=10 to http://httpbin.org/post ...
#                           good/b/f t   good%   min [p50 p95 p99  p999]  max change
2016-12-19T16:12:45-05:00   4009/0/0 10000  40% 10s  12 [ 18  30  52 2895 ] 2895 +
2016-12-19T16:12:55-05:00   4814/0/0 10000  48% 10s  12 [ 18  30  41  339 ]  339
2016-12-19T16:13:05-05:00   4822/0/0 10000  48% 10s  12 [ 19  31  49  154 ]  154
FROM    TO #REQUESTS
   0     2 0
   2     8 0
   8    32 13087
  32    64 499
  64   128 34
 128   256 11
 256   512 6
 512  1024 1
1024  4096 7
4096 16384 0

real	0m30.062s
user	0m1.915s
sys	0m1.551s

→ time ./slow_cooker_with_lua -qps 100 -concurrency 10 -dataGeneratorScript ./randomstring.lua -method POST -totalRequests 1000 http://httpbin.org/post
# sending 1000 POST req/s with concurrency=10 to http://httpbin.org/post ...
#                           good/b/f t   good%   min [p50 p95 p99  p999]  max change
2016-12-19T16:14:54-05:00   4795/0/0 10000  47% 10s  12 [ 19  30  41  232 ]  232 +
FROM    TO #REQUESTS
   0     2 0
   2     8 0
   8    32 4632
  32    64 152
  64   128 10
 128   256 1
 256   512 0
 512  1024 0
1024  4096 0
4096 16384 0

real	0m10.057s
user	0m1.306s
sys	0m0.577s
```