### PR TITLE
Rename good% to goal%, start counting bad requests toward goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next release
+### Changed
+- Renamed `good%` column to `goal%`, and started counting bad requests toward goal.
 
 ## [1.1.0] - 2017-01-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,11 +139,12 @@ slowdowns. If you're running multi-hour tests, bumping up the reporting
 interval to 60 seconds (`60s` or `1m`) is recommended.
 
 ```
-$timestamp $good/$bad/$failed $trafficGoal $percentGood $interval $min [$p50 $p95 $p99 $p999] $max
+$timestamp $good/$bad/$failed $trafficGoal $percentGoal $interval $min [$p50 $p95 $p99 $p999] $max
 ```
 
-`bad` means a status code in the 500 range. `failed` means a
-connection failure.
+`bad` means a status code in the 500 range. `failed` means a connection failure.
+`percentGoal` is calculated as the total number of `good` and `bad` requests as
+a percentage of `trafficGoal`.
 
 ## Tips and tricks
 

--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func main() {
 	intPadding := strings.Repeat(" ", intLen-2)
 
 	fmt.Printf("# sending %d %s req/s with concurrency=%d to %s ...\n", (*qps * *concurrency), *method, *concurrency, dstURL)
-	fmt.Printf("# %s good/b/f t   good%% %s min [p50 p95 p99  p999]  max change\n", timePadding, intPadding)
+	fmt.Printf("# %s good/b/f t   goal%% %s min [p50 p95 p99  p999]  max change\n", timePadding, intPadding)
 	for i := 0; i < *concurrency; i++ {
 		ticker := time.NewTicker(timeToWait)
 		go func() {
@@ -353,7 +353,7 @@ func main() {
 				min = 0
 			}
 			// Periodically print stats about the request load.
-			percentAchieved := int(math.Min(((float64(good) /
+			percentAchieved := int(math.Min((((float64(good) + float64(bad)) /
 				float64(totalTrafficTarget)) * 100), 100))
 
 			lastP99 := int(hist.ValueAtQuantile(99))


### PR DESCRIPTION
As discussed in person with @stevej, I was expecting the `good%` column to reflect the total number of requests sent, regardless of whether or not they returned a 2xx response. We decided to rename the `good%` column to `goal%`, and to start counting bad requests toward the goal.