### PR TITLE
Fix “case-insensitive import collision”

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM library/golang:1.7.3
 
 WORKDIR /go/src/slow_cooker
 
-ADD . /go/src/github.com/buoyantio/slow_cooker
+ADD . /go/src/github.com/BuoyantIO/slow_cooker
 
-RUN go build -o /go/bin/slow_cooker /go/src/github.com/buoyantio/slow_cooker/main.go
+RUN go build -o /go/bin/slow_cooker /go/src/github.com/BuoyantIO/slow_cooker/main.go
 
 ENTRYPOINT ["/go/bin/slow_cooker"]

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/buoyantio/slow_cooker",
+	"ImportPath": "github.com/BuoyantIO/slow_cooker",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v76",
 	"Packages": [

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   override:
-    - mkdir -p ~/src/github.com/buoyantio
-    - ln -s ~/slow_cooker ~/src/github.com/buoyantio
+    - mkdir -p ~/src/github.com/BuoyantIO
+    - ln -s ~/slow_cooker ~/src/github.com/BuoyantIO
 test:
   override:
-    - cd ~/src/github.com/buoyantio/slow_cooker && GOPATH=~/ go test -v ./...
+    - cd ~/src/github.com/BuoyantIO/slow_cooker && GOPATH=~/ go test -v ./...

--- a/main.go
+++ b/main.go
@@ -23,9 +23,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/buoyantio/slow_cooker/hdrreport"
-	"github.com/buoyantio/slow_cooker/ring"
-	"github.com/buoyantio/slow_cooker/window"
+	"github.com/BuoyantIO/slow_cooker/hdrreport"
+	"github.com/BuoyantIO/slow_cooker/ring"
+	"github.com/BuoyantIO/slow_cooker/window"
 	"github.com/codahale/hdrhistogram"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/release.sh
+++ b/release.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-GOOS=linux GOARCH=amd64  go build -o slow_cooker_linux_amd64 github.com/buoyantio/slow_cooker
-GOOS=linux GOARCH=arm    go build -o slow_cooker_linux_arm   github.com/buoyantio/slow_cooker
-GOOS=darwin GOARCH=amd64 go build -o slow_cooker_darwin      github.com/buoyantio/slow_cooker
+GOOS=linux GOARCH=amd64  go build -o slow_cooker_linux_amd64 github.com/BuoyantIO/slow_cooker
+GOOS=linux GOARCH=arm    go build -o slow_cooker_linux_arm   github.com/BuoyantIO/slow_cooker
+GOOS=darwin GOARCH=amd64 go build -o slow_cooker_darwin      github.com/BuoyantIO/slow_cooker
 echo "releases built:"
 ls slow_cooker_*


### PR DESCRIPTION
When building slow_cooker locally (under go1.8, in case it's a recent thing), I get:

```
can't load package: package github.com/BuoyantIO/slow_cooker: case-insensitive import collision: "github.com/BuoyantIO/slow_cooker/vendor/github.com/codahale/hdrhistogram" and "github.com/buoyantio/slow_cooker/vendor/github.com/codahale/hdrhistogram"
```

So I updated all the things to use the canonical `BuoyantIO/slow_cooker` form. 👓 