### PR TITLE
Make http client timeout configurable via command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ or:
 | `-concurrency`        | 1         | Number of goroutines to run, each at the specified QPS level. Measure total QPS as `qps * concurrency`. |
 | `-compress`           | `<unset>` | If set, ask for compressed responses. |
 | `-data`               | `<none>`  | Include the specified body data in requests. If the data starts with a '@' the remaining value will be treated as a file path to read the body data from, or if the data value is '@-', the body data will be read from stdin. |
+| `-hashSampleRate`     | `0.0`     | Sampe Rate for checking request body's hash. Interval in the range of [0.0, 1.0] |
+| `-hashValue`          | `<none>`  | fnv-1a hash value to check the request body against |
 | `-header`             | `<none>`  | Adds additional headers to each request. Can be specified multiple times. Format is `key: value`. |
 | `-host`               | `<none>`  | Overrides the default host header value that's set on each request. |
 | `-interval`           | 10s       | How often to report stats to stdout. |
@@ -37,10 +39,9 @@ or:
 | `-noLatencySummary`   | `<unset>` | If set, don't print the latency histogram report at the end. |
 | `-noreuse`            | `<unset>` | If set, do not reuse connections. Default is to reuse connections. |
 | `-reportLatenciesCSV` | `<none>`  | Filename to write CSV latency values. Format of CSV is millisecond buckets with number of requests in each bucket. |
+| `-timeout`            | 10s       | Individual request timeout. |
 | `-totalRequests`      | `<none>`  | Exit after sending this many requests. |
 | `-help`               | `<unset>` | If set, print all available flags and exit. |
-| `-hashSampleRate`     | `0.0`     | Sampe Rate for checking request body's hash. Interval in the range of [0.0, 1.0] |
-| `-hashValue`          | `<none>`  | fnv-1a hash value to check the request body against |
 
 # Using multiple Host headers
 


### PR DESCRIPTION
For some tests, it's useful to set a more aggressive per-request timeout than the 10 second default. Adding a `-timeout` flag to support that.