### PR TITLE
Add -iterations to specify a budget for the experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ or:
 |-----------------------|-----------|-------------|
 | `-qps`                | 1         | QPS to send to backends per request thread. |
 | `-concurrency`        | 1         | Number of goroutines to run, each at the specified QPS level. Measure total QPS as `qps * concurrency`. |
+| `-iterations`         | 0         | Number of iterations for the experiment. Exits gracefully after `iterations * interval` (default 0, meaning infinite). |
 | `-compress`           | `<unset>` | If set, ask for compressed responses. |
 | `-data`               | `<none>`  | Include the specified body data in requests. If the data starts with a '@' the remaining value will be treated as a file path to read the body data from, or if the data value is '@-', the body data will be read from stdin. |
 | `-hashSampleRate`     | `0.0`     | Sampe Rate for checking request body's hash. Interval in the range of [0.0, 1.0] |

--- a/main.go
+++ b/main.go
@@ -303,6 +303,7 @@ func shouldCheckHash(sampleRate float64) bool {
 func main() {
 	qps := flag.Int("qps", 1, "QPS to send to backends per request thread")
 	concurrency := flag.Int("concurrency", 1, "Number of request threads")
+	numIterations := flag.Uint64("iterations", 0, "Number of iterations (0 for infinite)")
 	host := flag.String("host", "", "value of Host header to set")
 	method := flag.String("method", "GET", "HTTP method to use")
 	interval := flag.Duration("interval", 10*time.Second, "reporting interval")
@@ -513,6 +514,10 @@ func main() {
 				changeIndicator)
 
 			iteration++
+
+			if *numIterations > 0 && iteration >= *numIterations {
+				cleanup <- true
+			}
 			count = 0
 			size = 0
 			good = 0

--- a/main.go
+++ b/main.go
@@ -443,7 +443,7 @@ func main() {
 		}(i % len(dstURLs))
 	}
 
-	cleanup := make(chan bool, 2)
+	cleanup := make(chan bool, 3)
 	interrupted := make(chan os.Signal, 2)
 	signal.Notify(interrupted, syscall.SIGINT)
 


### PR DESCRIPTION
If `iterations` is greater than 0, the experiment will not be infinite, but print N reports and exit automatically afterwards.