### PR TITLE
Update Go to 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.11.5-stretch
+    - image: circleci/golang:1.14.2-stretch
     steps:
     - checkout
     - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-stretch as build
+FROM golang:1.14.2-stretch as build
 
 WORKDIR /slow_cooker
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -installsuffix cgo -o ./slow_cooker
 
-FROM alpine:3.9
+FROM alpine:3.12
 RUN apk --update upgrade && \
     apk add ca-certificates curl nghttp2 && \
     update-ca-certificates && \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Releasing slow_cooker
 
 Once all of the branches for the release have been merged and the CHANGELOG.md
-file in master has been updated to describe the new release, use these
+file in main has been updated to describe the new release, use these
 instructions to publish the release to Github and Docker Hub.
 
 ## Github

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/buoyantio/slow_cooker
 
+go 1.14
+
 require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
 	github.com/kr/pretty v0.1.0 // indirect


### PR DESCRIPTION
Update go.mod, CircleCI, and Dockerfile to Go 1.14.2, Alpine 3.12.

Also update the docs to reflect the default branch is now `main`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>